### PR TITLE
Revert "property: Make the adb tcp port property a wildcard"

### DIFF
--- a/property_contexts
+++ b/property_contexts
@@ -31,7 +31,7 @@ debug.                  u:object_r:debug_prop:s0
 debug.db.               u:object_r:debuggerd_prop:s0
 log.                    u:object_r:shell_prop:s0
 service.adb.root        u:object_r:shell_prop:s0
-service.adb.tcp.port*   u:object_r:shell_prop:s0
+service.adb.tcp.port    u:object_r:shell_prop:s0
 
 persist.audio.          u:object_r:audio_prop:s0
 persist.logd.           u:object_r:logd_prop:s0


### PR DESCRIPTION
- Causes android.cts.security.SELinuxHostTest#testAospPropertyContexts
  test failure since it's looking for an exact string match.

This reverts commit 60ddcc03e9401c3fb1e064bb84171a112a9bb8be.

Change-Id: I66b5e1d59588be7b73b49f9b0e06d4834a008cf3
